### PR TITLE
Ignore patch number if samtools version uses it

### DIFF
--- a/VISOR/LASeR/LASeR.py
+++ b/VISOR/LASeR/LASeR.py
@@ -418,7 +418,7 @@ def run(parser,args):
 			#check version (only for samtools?)
 			if x == 'samtools':
 
-				major,minor,patch=subprocess.check_output(['samtools', '--version']).decode('utf-8').split('\n')[0].split('samtools ')[1].split('.')
+				major,minor=subprocess.check_output(['samtools', '--version']).decode('utf-8').split('\n')[0].split('samtools ')[1].split('.')[:2]
 
 				if int(major) < 1 or int(minor) < 9:
 

--- a/VISOR/LASeR/LASeR.py
+++ b/VISOR/LASeR/LASeR.py
@@ -418,7 +418,7 @@ def run(parser,args):
 			#check version (only for samtools?)
 			if x == 'samtools':
 
-				major,minor=subprocess.check_output(['samtools', '--version']).decode('utf-8').split('\n')[0].split('samtools ')[1].split('.')
+				major,minor,patch=subprocess.check_output(['samtools', '--version']).decode('utf-8').split('\n')[0].split('samtools ')[1].split('.')
 
 				if int(major) < 1 or int(minor) < 9:
 


### PR DESCRIPTION
The version code fails as it doesn't expect a patch number, present in the latest samtools version in bioconda (1.15.1). This PR simply ignores it if it exists.